### PR TITLE
repush: fix issue 21 (uppercase file extensions)

### DIFF
--- a/host/repush.sh
+++ b/host/repush.sh
@@ -300,7 +300,7 @@ function check_file {
     echo "repush: Unsupported file format: $1"
     echo "repush: Only PDFs and EPUBs are supported"
     return 0
-  elif [ -z $is_directory ] && ! echo "$1" | grep -qP "\.pdf$" && ! echo "$1" | grep -qP "\.epub$" ; then
+  elif [ -z $is_directory ] && ! echo "$1" | grep -qi "\.pdf$" && ! echo "$1" | grep -qi "\.epub$" ; then
     echo "repush: File extension invalid or missing: $1"
     return 0
   elif echo "$1" | grep -q '"'; then


### PR DESCRIPTION
Fixes #21. The `-P` switch for grep was not needed, so I removed it in order to increase compatibility with Mac OS. `-i` was added to allow for upper case file extensions.

Tested on 1.7.