### PR TITLE
Add realpath to scp argument

### DIFF
--- a/host/repush.sh
+++ b/host/repush.sh
@@ -381,7 +381,7 @@ function push {
         # Replace placeholder with document
         retry=""
         while true; do
-          scp "$1" root@"$SSH_ADDRESS":"/home/root/.local/share/remarkable/xochitl/$RET_UUID.$extension"
+          scp "$(realpath "$1")" root@"$SSH_ADDRESS":"/home/root/.local/share/remarkable/xochitl/$RET_UUID.$extension"
 
           if [ $? -ne 0 ]; then
             read -r -p "Failed to replace placeholder! Retry? [Y/n]: " retry


### PR DESCRIPTION
This ensures that files with a colon `:` in their name can be uploaded.

The SCP manual states:

> Local file names can be made explicit using absolute or relative pathnames to avoid scp treating file names containing ‘:’ as host specifiers.

---

Problems with this PR: it adds a dependency on realpath (coreutils)