### PR TITLE
Portable way of using heredocs. Fixes #14 on macOS.

### DIFF
--- a/host/repush.sh
+++ b/host/repush.sh
@@ -69,8 +69,7 @@ function create_placeholder_pdf {
 
 # $1 - Output directory
 function create_placeholder_epub {
-
-echo "$(cat <<- 'EOF'
+  cat << 'EOF' | xxd -r > "$1"
 00000000: 504b 0304 1400 1608 0000 a173 b74e 6f61  PK.........s.Noa
 00000010: ab2c 1400 0000 1400 0000 0800 0000 6d69  .,............mi
 00000020: 6d65 7479 7065 6170 706c 6963 6174 696f  metypeapplicatio
@@ -196,8 +195,6 @@ echo "$(cat <<- 'EOF'
 000007a0: 732e 7478 7450 4b05 0600 0000 0006 0006  s.txtPK.........
 000007b0: 006c 0100 0039 0600 0000 00              .l...9.....
 EOF
-)" | xxd -r > "$1"
-
 }
 
 # Grep remote fs (grep on reMarkable)

--- a/host/webui_invincibility.sh
+++ b/host/webui_invincibility.sh
@@ -100,7 +100,7 @@ function usage {
 }
 
 function patch_xochitl {
-echo "$(cat <<- 'EOF'
+  cat << 'EOF' | xxd -r > "/tmp/webui_invincibility.patch"
 00000000: 4253 4449 4646 3430 3a00 0000 0000 0000  BSDIFF40:.......
 00000010: 3a00 0000 0000 0000 c437 4200 0000 0000  :........7B.....
 00000020: 425a 6839 3141 5926 5359 e208 05e2 0000  BZh91AY&SY......
@@ -113,8 +113,6 @@ echo "$(cat <<- 'EOF'
 00000090: 9098 6eec 425a 6839 1772 4538 5090 0000  ..n.BZh9.rE8P...
 000000a0: 0000                                     ..
 EOF
-)" | xxd -r > "/tmp/webui_invincibility.patch"
-
   if [ ! -f "/tmp/webui_invincibility.patch" ]; then
     echo "webui_invincibility: Failed to create patchfile!"
     return 1


### PR DESCRIPTION
This fixes the issue #14 about `repush.sh` failing on macOS with a Bash syntax error. With this fix it should work on all systems (tested to work on macOS, and per my understanding of the standards, it should not cause a problem anywhere).

I learned of this from https://stackoverflow.com/a/2954835 (see “To pipe the heredoc through a command pipeline”) and from https://stackoverflow.com/a/7046926 which points to https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07_04